### PR TITLE
Fixing issues with newlines, plus smaller improvements

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,8 +7,15 @@ function SendToCalendarOuter(data, tab) {
     chrome.tabs.executeScript( {
         code: "window.getSelection().toString();"
     }, function(selection) {
-        // selection[0] contains text including line breaks
-        SendToCalendar(selection[0], tab);
+        if (selection) {
+            // selection[0] contains text including line breaks
+            SendToCalendar(selection[0], tab);
+        } else if (data.selectionText) {
+            // data.selectionText contains text without line breaks
+            SendToCalendar(data.selectionText, tab);
+        } else {
+            SendToCalendar("", tab);
+        }
     });
 }
 
@@ -20,9 +27,11 @@ function SendToCalendar(selection, tab) {
     // but we don't surpass it by more than a few tens of chars.)
     var maxLength = 1600;
 
+    // Start building the URL
+	var url = "http://www.google.com/calendar/event?action=TEMPLATE";
+    
     // Page title to event title
-	var url = "http://www.google.com/calendar/event?action=TEMPLATE"
-        + "&text=" + TrimURITo(tab.title, maxLength);
+    url += "&text=" + TrimURITo(tab.title, maxLength);
 
     // Check if the selected text contains a US formatted address
     // and it its first 100 chars to URI if so

--- a/background.js
+++ b/background.js
@@ -1,49 +1,70 @@
-//create the context menu 
-var cmSendToCalendar = chrome.contextMenus.create({ "title": "Send To Calendar", "contexts": ["all"], "onclick": SendToCalendar });
+// Create the context menu
+var cmSendToCalendar = chrome.contextMenus.create({ "title": "Send To Calendar", "contexts": ["all"], "onclick": SendToCalendarOuter });
 
-//do all the things
-function SendToCalendar(data, tab) {
-    
-	var location = "";
-	var selection = "";
+// Do all the things
+function SendToCalendarOuter(data, tab) {
+    // Preserve newlines in the selection
+    chrome.tabs.executeScript( {
+        code: "window.getSelection().toString();"
+    }, function(selection) {
+        // selection[0] contains text including line breaks
+        SendToCalendar(selection[0], tab);
+    });
+}
+
+function SendToCalendar(selection, tab) {
+
+    // Max URI length is 2000 chars, but let's keep under 1600
+    // to also allow a buffer for google login/redirect urls etc.
+    // (This limit is not a hard limit in the code,
+    // but we don't surpass it by more than a few tens of chars.)
+    var maxLength = 1600;
+
+    // Page title to event title
+	var url = "http://www.google.com/calendar/event?action=TEMPLATE"
+        + "&text=" + TrimURITo(tab.title, maxLength);
+
+    // Check if the selected text contains a US formatted address
+    // and it its first 100 chars to URI if so
+    var address = selection.match(/(\d+\s+[':.,\s\w]*,\s*[A-Za-z]+\s*\d{5}(-\d{4})?)/m);
+    if (address) {
+        // Location goes to location
+        url += "&location=" + TrimURITo(address[0], maxLength - url.length);
+    }
+
+    // URL goes to star of details (event description)
+    var taburl = TrimURITo(tab.url + "\n\n", maxLength - url.length);
+
+    // Selection goes to end of details, and to ctext (google calendar quick add),
+    // (trim to half of the available length cause its twice in the URI)
+    var selection = TrimURITo(selection, (maxLength - url.length)/2);
+    url += "&details=" + selection + "&ctext=" + selection;
 	
-	if (data.selectionText) {
-		//get the selected text and uri encode it
-		selection = data.selectionText;
-		
-		//check if the selected text contains a US formatted address
-		var address = data.selectionText.match(/(\d+\s+[':.,\s\w]*,\s*[A-Za-z]+\s*\d{5}(-\d{4})?)/m);
-		if (address) 
-			location = "&location=" + address[0];
-	}
-	
-	//build the url: selection goes to ctext (google calendar quick add), page title to event title, and include url in description
-	var url = "http://www.google.com/calendar/event?action=TEMPLATE&text=" + tab.title + location +
-	"&details=" + tab.url + "  " + selection + "&ctext=" + selection;
-	
-	//url encode (with special attention to spaces & paragraph breaks) 
-	//and trim at 1,000 chars to account for 2,000 character limit with buffer for google login/redirect urls
-	url = encodeURI(url.replaceAll("  ", "\n\n")).replaceAll("%20", "+").replaceAll("%2B", "+").substring(0,1000);
-	
-	//the substring might cut the url in the middle of a url encoded value, so we need to strip any trailing % or %X chars to avoid an error 400
-	if (url.substr(url.length-1) === "%") {url = url.substring(0,url.length-1)}
-	else if(url.substr(url.length-2,1) === "%" ) {url = url.substring(0,url.length-2)}
-	
-	//open the created url in a new tab
+    // Open the created url in a new tab
 	chrome.tabs.create({ "url": url}, function (tab) {});
-	
 }
 
-//helper replaceAll function
-String.prototype.replaceAll = function(strTarget, strSubString){
-	var strText = this;
-	var intIndexOfMatch = strText.indexOf( strTarget );
-	 
-	while (intIndexOfMatch != -1){
-		strText = strText.replace( strTarget, strSubString )
-		intIndexOfMatch = strText.indexOf( strTarget );
-	}
+// Trim text so that its URI encoding fits into the length limit
+// and return its URI encoding
+function TrimURITo(text, length) {
+    var textURI = encodeURI(text);
+    if (textURI.length > length) {
+        // Different charsets can lead to a different blow-up after passing the
+        // text through encodeURI, so let's estimate the blow up first,
+        // and then trim the text so that it fits the limit...
+        var blowUp = textURI.length/text.length;
+        var newLength = Math.floor(length / blowUp) - 3;  // -3 for "..."
+        do {
+            // trim the text & show that it was trimmed...
+            text = text.substring(0, newLength) + "...";
+            textURI = encodeURI(text);
+            newLength = Math.floor(0.9 * newLength);
+        } while (textURI.length > length);
+    }
 
-	return( strText );
-	
+    return textURI;
 }
+
+// TODO: configuration to choose whether I want tab.title to fill the text,
+// or wherher to allow Google calendar to fill it by itself from ctext
+

--- a/background.js
+++ b/background.js
@@ -31,7 +31,7 @@ function SendToCalendar(selection, tab) {
 	var url = "http://www.google.com/calendar/event?action=TEMPLATE";
     
     // Page title to event title
-    url += "&text=" + TrimURITo(tab.title, maxLength);
+    // url += "&text=" + TrimURITo(tab.title, maxLength);
 
     // Check if the selected text contains a US formatted address
     // and it its first 100 chars to URI if so
@@ -42,12 +42,17 @@ function SendToCalendar(selection, tab) {
     }
 
     // URL goes to star of details (event description)
-    var taburl = TrimURITo(tab.url + "\n\n", maxLength - url.length);
+    url += "&details=" + TrimURITo(tab.url + "\n\n", maxLength - url.length);
 
     // Selection goes to end of details, and to ctext (google calendar quick add),
     // (trim to half of the available length cause its twice in the URI)
-    var selection = TrimURITo(selection, (maxLength - url.length)/2);
-    url += "&details=" + selection + "&ctext=" + selection;
+    var selection = TrimURITo(selection, (maxLength - url.length - title.length)/2);
+    url += selection;
+    // ctext is also prepended with tab.title,
+    // so that Google Calendar can use it to generate the text,
+    // but can also include other info.
+    var title = TrimURITo(tab.title + "\n", maxLength - url.length);
+    url += "&ctext=" + title + selection;
 	
     // Open the created url in a new tab
 	chrome.tabs.create({ "url": url}, function (tab) {});
@@ -74,6 +79,4 @@ function TrimURITo(text, length) {
     return textURI;
 }
 
-// TODO: configuration to choose whether I want tab.title to fill the text,
-// or wherher to allow Google calendar to fill it by itself from ctext
-
+// TODO: configuration to include tab.url in description?

--- a/background.js
+++ b/background.js
@@ -46,13 +46,12 @@ function SendToCalendar(selection, tab) {
 
     // Selection goes to end of details, and to ctext (google calendar quick add),
     // (trim to half of the available length cause its twice in the URI)
-    var selection = TrimURITo(selection, (maxLength - url.length - title.length)/2);
-    url += selection;
     // ctext is also prepended with tab.title,
     // so that Google Calendar can use it to generate the text,
     // but can also include other info.
     var title = TrimURITo(tab.title + "\n", maxLength - url.length);
-    url += "&ctext=" + title + selection;
+    var selection = TrimURITo(selection, (maxLength - url.length)/2 - title.length);
+    url += selection + "&ctext=" + title + selection;
 	
     // Open the created url in a new tab
 	chrome.tabs.create({ "url": url}, function (tab) {});

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "Send to Calendar",
-  "version": "0.11",
+  "version": "0.20",
   "description": "Send events to Google Calendar automagically from any webpage. No more re-typing! Select text, right click, and 'Send to Calendar.'",
   "icons": { "16": "icon16.png", "48": "icon48.png", "128": "icon128.png" },
-  "permissions": ["contextMenus"],
+  "permissions": ["tabs", "contextMenus", "http://*/", "https://*/" ],
   "background": { "scripts": ["background.js"] },
   "browser_action": {"default_icon": "icon16.png"},
   "manifest_version": 2


### PR DESCRIPTION
Chrome has this weird bug/feature of replacing newlines by spaces in selectionText: https://bugs.chromium.org/p/chromium/issues/detail?id=116429
This means that when selecting a multiline text and sending it to calendar, it all gets squashed into a single line (unless there is an empty line, which would produce a double space, and the original code would then translate this back into an empty line).
However, the bug tracker also lists a workaround, so I implemented it into the extension.

I also changed the behaviour in terms of generating the "text" (title of the event).
Originally, it would set the tab title as the text, which may or may not be appropriate (the selected text may be better; this was also indicated in reviews of the extension).
I changed it not to set text directly, but to prepend tab.title to ctext. This means that typically, tab.title will still be the first thing in text, but other text from the selection can also make it there. This seems better to me.

I also cleaned the code a bit.
